### PR TITLE
Using crit bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2022-09-29
+
+### Changed
+
+- Using Movemate's implementation of critbit (sorted binary tree) instead of
+  the naive implementation with two sorted arrays.
+- Renamed package to `Syrup`
+
 ## [0.3.0] - 2022-09-27
 
 ### Changed

--- a/Move.toml
+++ b/Move.toml
@@ -1,11 +1,11 @@
 [package]
-name = "NftLiquidityLayer"
-version = "0.3.0"
+name = "Syrup"
+version = "0.4.0"
 
 [dependencies]
 NftProtocol = { git = "https://github.com/Origin-Byte/nft-protocol", rev = "0.3.0" }
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "devnet-0.9.0" }
 
 [addresses]
-nft_liquidity_layer = "0x0"
+syrup = "0x0"
 # nft_protocol = "0xe6d6f01725d469b7b04d9905e6b3151e8c4264cb"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ $ sui move build
 
 # Orderbook
 
-_(Orderbook is not optimized yet)_
-
 Orderbook implementation where bids are fungible tokens and asks are NFTs.
 A bid is a request to buy one NFT from a specific collection.
 An ask is one NFT with a min price condition.

--- a/examples/custom_collection.move
+++ b/examples/custom_collection.move
@@ -1,4 +1,4 @@
-module nft_liquidity_layer::custom_collection {
+module syrup::custom_collection {
     //! A simple showcase how to participate in the liquidity layer as a custom
     //! collection implementor.
     //!
@@ -12,7 +12,7 @@ module nft_liquidity_layer::custom_collection {
     //! It would implements royalty distribution based on a business logic which
     //! makes most sense for art NFTs.
 
-    use nft_liquidity_layer::orderbook::{Self, Orderbook};
+    use syrup::orderbook::{Self, Orderbook};
     use std::fixed_point32;
     use sui::object::{Self, UID};
     use sui::balance;

--- a/examples/name_service.move
+++ b/examples/name_service.move
@@ -1,4 +1,4 @@
-module nft_liquidity_layer::name_service {
+module syrup::name_service {
     //! This example showcases custom implementation for logic creating an ask.
     //!
     //! Now, marketplaces and wallets have two options: implement creating ask
@@ -10,7 +10,7 @@ module nft_liquidity_layer::name_service {
 
     use nft_protocol::collection::{Self, Collection};
     use nft_protocol::nft::NftOwned;
-    use nft_liquidity_layer::orderbook::{Self, Orderbook};
+    use syrup::orderbook::{Self, Orderbook};
     use std::fixed_point32;
     use std::option::Option;
     use std::string::String;

--- a/sources/err.move
+++ b/sources/err.move
@@ -1,4 +1,4 @@
-module nft_liquidity_layer::err {
+module syrup::err {
     //! Exports error functions. All errors in this smart contract have a prefix
     //! which distinguishes them from errors in other packages.
 


### PR DESCRIPTION

## [0.4.0] - 2022-09-29

### Changed

- Using Movemate's implementation of critbit (sorted binary tree) instead of
  the naive implementation with two sorted arrays.
- Renamed package to `Syrup`